### PR TITLE
Add converting functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "parse-color": "^1.0.0",
     "postcss": "^6.0.6",
-    "postcss-color-function": "^4.0.0",
+    "postcss-cssnext": "^2.9.0",
     "postcss-simple-vars": "^4.0.0",
     "q": "^1.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-galen-color-variables",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Export PostCSS color variables to Galen Test Suite syntax",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@bitbucket.org/samuelthomps0n/postcss-galen-color-variables.git"
+    "url": "git+ssh://git@github.com/samuelthomps0n/postcss-galen-color-variables.git"
   },
   "keywords": [
     "PostCSS",
@@ -17,7 +17,7 @@
   ],
   "author": "Samuel Thompson <sam@samuelthompson.co.uk>",
   "license": "ISC",
-  "homepage": "https://bitbucket.org/samuelthomps0n/postcss-galen-color-variables#readme",
+  "homepage": "https://github.com/samuelthomps0n/postcss-galen-color-variables#readme",
   "dependencies": {
     "parse-color": "^1.0.0",
     "postcss": "^6.0.6",

--- a/test/fixtures/test.css
+++ b/test/fixtures/test.css
@@ -1,5 +1,6 @@
 :root {
     --variableName: #242424;
+    --variableNameFunc: color(var(--variableName) tint(80%));
 }
 
 $oldVariable: #343434;

--- a/test/fixtures/test.expected.gspec
+++ b/test/fixtures/test.expected.gspec
@@ -4,6 +4,10 @@
     colorVariableNameRGBA  rgba(36, 36, 36, 1)
     colorVariableNameHEX  #242424
 
+    colorVariableNameFuncRGB  rgb(211, 211, 211)
+    colorVariableNameFuncRGBA  rgba(211, 211, 211, 1)
+    colorVariableNameFuncHEX  #d3d3d3
+
     colorOldVariableRGB  rgb(52, 52, 52)
     colorOldVariableRGBA  rgba(52, 52, 52, 1)
     colorOldVariableHEX  #343434

--- a/test/fixtures/test.gspec
+++ b/test/fixtures/test.gspec
@@ -4,6 +4,10 @@
     colorVariableNameRGBA  rgba(36, 36, 36, 1)
     colorVariableNameHEX  #242424
 
+    colorVariableNameFuncRGB  rgb(211, 211, 211)
+    colorVariableNameFuncRGBA  rgba(211, 211, 211, 1)
+    colorVariableNameFuncHEX  #d3d3d3
+
     colorOldVariableRGB  rgb(52, 52, 52)
     colorOldVariableRGBA  rgba(52, 52, 52, 1)
     colorOldVariableHEX  #343434


### PR DESCRIPTION
We use the color() function in places on the site, which causes
this convertor to fail as it didnt close the final brackets correctly.

This change will run postcss-cssnext to convert the functions to color
strings which can then be passed through the rest of our convertor.